### PR TITLE
Fix variable typos and cleanup shot handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# asteroids
+# Asteroids
+
+A simple Asteroids clone written with **pygame**. Use `WASD` to maneuver your ship and `SPACE` to fire shots. Destroy asteroids, collect power-ups and aim for a high score.
+
+## Requirements
+
+- Python 3
+- pygame 2.6.0 (see `requirements.txt`)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the game with:
+
+```bash
+python main.py
+```
+

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def main():
     PowerUp.containers = (powerups_group, updatable, drawable) # Assign containers for PowerUp
 
     player = Player(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)
-    ateroid_field = AsteroidField() # Creates initial asteroids which get added to groups
+    asteroid_field = AsteroidField() # Creates initial asteroids which get added to groups
     pause_menu = PauseMenu(SCREEN_WIDTH, SCREEN_HEIGHT)
     resume_rect = None
     quit_rect = None
@@ -91,7 +91,7 @@ def main():
                         for p in powerups_group: p.kill() # Clear existing power-ups
 
                         player = Player(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2) # Re-creates and adds to groups
-                        ateroid_field = AsteroidField() # Re-creates and adds asteroids to groups
+                        asteroid_field = AsteroidField() # Re-creates and adds asteroids to groups
                         
                         paused = False
                         game_state = "PLAYING"

--- a/shot.py
+++ b/shot.py
@@ -1,5 +1,5 @@
 from circleshape import CircleShape
-from constants import SHOT_RADIUS
+from constants import SHOT_RADIUS, SCREEN_WIDTH, SCREEN_HEIGHT
 import pygame
 
 
@@ -12,3 +12,11 @@ class Shot(CircleShape):
 
     def update(self, dt):
         self.position += self.velocity * dt
+
+        if (
+            self.position.x < -self.radius
+            or self.position.x > SCREEN_WIDTH + self.radius
+            or self.position.y < -self.radius
+            or self.position.y > SCREEN_HEIGHT + self.radius
+        ):
+            self.kill()


### PR DESCRIPTION
## Summary
- fix `asteroid_field` typo in `main.py`
- kill `Shot` when it moves off screen
- expand documentation and add newline to README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68420e11696c832397ccc21d9fd12e75