### PR TITLE
Fix CircleShape group init

### DIFF
--- a/circleshape.py
+++ b/circleshape.py
@@ -4,9 +4,10 @@ import pygame
 # Base class for game objects
 class CircleShape(pygame.sprite.Sprite):
     def __init__(self, x, y, radius):
-        # we will be using this later
-        if hasattr(self, "containers"):
-            super().__init__(self.containers)  # type: ignore
+        # Add to sprite groups only if containers are set
+        containers = getattr(self, "containers", None)
+        if containers:
+            super().__init__(containers)  # type: ignore
         else:
             super().__init__()
 


### PR DESCRIPTION
## Summary
- tweak CircleShape initialization to only add groups when containers are set

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f20be6cfc8323ad987cf4a74d45ea