### PR TITLE
Add shield and spread shot power-ups

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,12 @@ from shot import Shot
 import sys
 import random # For power-up spawning chance
 from pause_menu import PauseMenu
-from powerup import RapidFirePowerUp, PowerUp # Import PowerUp for containers
+from powerup import (
+    RapidFirePowerUp,
+    ShieldPowerUp,
+    SpreadShotPowerUp,
+    PowerUp,
+)
 
 
 def main():
@@ -106,8 +111,15 @@ def main():
             if not paused:
                 for asteroid in asteroids:
                     if asteroid.check_collision(player):
-                        game_state = "GAME_OVER" # Change state instead of exiting
-                        break # Exit collision check loop for this frame
+                        if player.shield_active:
+                            asteroid.split()
+                            player.shield_active = False
+                            player.powerup_timer = 0
+                            player.active_powerup_type = None
+                            player.active_powerup_color = None
+                        else:
+                            game_state = "GAME_OVER"  # Change state instead of exiting
+                            break  # Exit collision check loop for this frame
                 if game_state == "GAME_OVER": # Check again if collision changed state
                     continue # Skip rest of PLAYING logic for this frame
 
@@ -118,10 +130,16 @@ def main():
                             asteroid.split()
                             score += 10
                             # Spawn power-up chance
-                            if random.random() < 0.2: # 20% chance
-                                # PowerUp class handles adding to groups via PowerUp.containers
-                                RapidFirePowerUp(asteroid.position.x, asteroid.position.y)
-                                print(f"Spawned RapidFirePowerUp at ({asteroid.position.x}, {asteroid.position.y})")
+                            if random.random() < 0.2:  # 20% chance
+                                powerup_cls = random.choice([
+                                    RapidFirePowerUp,
+                                    ShieldPowerUp,
+                                    SpreadShotPowerUp,
+                                ])
+                                powerup_cls(asteroid.position.x, asteroid.position.y)
+                                print(
+                                    f"Spawned {powerup_cls.__name__} at ({asteroid.position.x}, {asteroid.position.y})"
+                                )
                             break # Assume one shot hits one asteroid part
                 
                 # Player-powerup collision

--- a/player.py
+++ b/player.py
@@ -31,6 +31,8 @@ class Player(pygame.sprite.Sprite, CircleShape):
         self.powerup_timer = 0.0 # Duration for active power-up
         self.active_powerup_type = None
         self.active_powerup_color = None # For visual indicator
+        self.shield_active = False
+        self.spread_shot_active = False
 
         # Add to groups if containers are set
         if Player.containers:
@@ -55,10 +57,14 @@ class Player(pygame.sprite.Sprite, CircleShape):
     def shoot(self):
         current_shoot_cooldown = PLAYER_SHOOT_COOLDOWN * self.shoot_cooldown_multiplier
         if self.timer <= 0:
-            new_shot = Shot(self.position.x, self.position.y)
-            new_shot.velocity = (
-                pygame.Vector2(0, 1).rotate(self.rotation) * PLAYER_SHOOT_SPEED
-            )
+            angles = [0]
+            if self.spread_shot_active:
+                angles = [-15, 0, 15]
+            for a in angles:
+                new_shot = Shot(self.position.x, self.position.y)
+                new_shot.velocity = (
+                    pygame.Vector2(0, 1).rotate(self.rotation + a) * PLAYER_SHOOT_SPEED
+                )
             self.timer = current_shoot_cooldown
 
     def draw(self, screen):
@@ -67,6 +73,8 @@ class Player(pygame.sprite.Sprite, CircleShape):
         # If we wanted the triangle to be on self.image, we'd render it there.
         current_draw_color = self.active_powerup_color if self.active_powerup_color else "white"
         pygame.draw.polygon(screen, current_draw_color, self.triangle(), 2)
+        if self.shield_active:
+            pygame.draw.circle(screen, "blue", (int(self.position.x), int(self.position.y)), self.radius + 5, 1)
 
     def update(self, dt):
         keys = pygame.key.get_pressed()
@@ -90,7 +98,12 @@ class Player(pygame.sprite.Sprite, CircleShape):
             self.powerup_timer -= dt
             if self.powerup_timer <= 0:
                 print(f"Power-up {self.active_powerup_type} expired.")
-                self.shoot_cooldown_multiplier = 1.0 # Reset effect
+                if self.active_powerup_type == "rapid_fire":
+                    self.shoot_cooldown_multiplier = 1.0
+                elif self.active_powerup_type == "shield":
+                    self.shield_active = False
+                elif self.active_powerup_type == "spread_shot":
+                    self.spread_shot_active = False
                 self.active_powerup_type = None
-                self.active_powerup_color = None # Reset color
+                self.active_powerup_color = None
                 self.powerup_timer = 0.0

--- a/powerup.py
+++ b/powerup.py
@@ -53,3 +53,41 @@ class RapidFirePowerUp(PowerUp):
         player.active_powerup_type = self.powerup_type
         player.active_powerup_color = self.color # Set player's active color
         print(f"Set player.shoot_cooldown_multiplier to 0.5, player.powerup_timer to {self.duration}, player.active_powerup_type to {self.powerup_type}, player.active_powerup_color to {self.color}")
+
+
+class ShieldPowerUp(PowerUp):
+    def __init__(self, x, y):
+        super().__init__(
+            x,
+            y,
+            radius=12,
+            color=(0, 0, 255),
+            powerup_type="shield",
+            duration=5.0,
+        )
+
+    def apply_effect(self, player):
+        print(f"Applying {self.powerup_type} to player for {self.duration}s.")
+        player.shield_active = True
+        player.powerup_timer = self.duration
+        player.active_powerup_type = self.powerup_type
+        player.active_powerup_color = self.color
+
+
+class SpreadShotPowerUp(PowerUp):
+    def __init__(self, x, y):
+        super().__init__(
+            x,
+            y,
+            radius=12,
+            color=(255, 165, 0),
+            powerup_type="spread_shot",
+            duration=5.0,
+        )
+
+    def apply_effect(self, player):
+        print(f"Applying {self.powerup_type} to player for {self.duration}s.")
+        player.spread_shot_active = True
+        player.powerup_timer = self.duration
+        player.active_powerup_type = self.powerup_type
+        player.active_powerup_color = self.color


### PR DESCRIPTION
## Summary
- implement `ShieldPowerUp` and `SpreadShotPowerUp`
- show a shield and handle spread shot in `Player`
- spawn random power-ups on asteroid destruction
- let shield negate one asteroid collision

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684f20d0d2e8832393035df6dc2ec562