### PR TITLE
Implement screen wrapping

### DIFF
--- a/asteroid.py
+++ b/asteroid.py
@@ -1,6 +1,10 @@
 import pygame
 from circleshape import CircleShape
-from constants import ASTEROID_MIN_RADIUS
+from constants import (
+    ASTEROID_MIN_RADIUS,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
+)
 import random
 
 
@@ -13,6 +17,16 @@ class Asteroid(CircleShape):
 
     def update(self, dt):
         self.position += self.velocity * dt
+
+        # Screen wrap-around
+        if self.position.x > SCREEN_WIDTH:
+            self.position.x = 0
+        elif self.position.x < 0:
+            self.position.x = SCREEN_WIDTH
+        if self.position.y > SCREEN_HEIGHT:
+            self.position.y = 0
+        elif self.position.y < 0:
+            self.position.y = SCREEN_HEIGHT
 
     def split(self):
         self.kill()

--- a/player.py
+++ b/player.py
@@ -6,6 +6,8 @@ from constants import (
     PLAYER_SHOOT_SPEED,
     PLAYER_TURN_SPEED,
     PLAYER_SPEED,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
 )
 from shot import Shot
 
@@ -83,7 +85,18 @@ class Player(pygame.sprite.Sprite, CircleShape):
             self.shoot()
 
         self.timer -= dt
-        self.rect.center = (int(self.position.x), int(self.position.y)) # Keep rect synced
+
+        # Screen wrap-around
+        if self.position.x > SCREEN_WIDTH:
+            self.position.x = 0
+        elif self.position.x < 0:
+            self.position.x = SCREEN_WIDTH
+        if self.position.y > SCREEN_HEIGHT:
+            self.position.y = 0
+        elif self.position.y < 0:
+            self.position.y = SCREEN_HEIGHT
+
+        self.rect.center = (int(self.position.x), int(self.position.y))  # Keep rect synced
 
         # Power-up timer update
         if self.powerup_timer > 0:

--- a/shot.py
+++ b/shot.py
@@ -13,10 +13,12 @@ class Shot(CircleShape):
     def update(self, dt):
         self.position += self.velocity * dt
 
-        if (
-            self.position.x < -self.radius
-            or self.position.x > SCREEN_WIDTH + self.radius
-            or self.position.y < -self.radius
-            or self.position.y > SCREEN_HEIGHT + self.radius
-        ):
-            self.kill()
+        # Screen wrap-around for shots
+        if self.position.x > SCREEN_WIDTH:
+            self.position.x = 0
+        elif self.position.x < 0:
+            self.position.x = SCREEN_WIDTH
+        if self.position.y > SCREEN_HEIGHT:
+            self.position.y = 0
+        elif self.position.y < 0:
+            self.position.y = SCREEN_HEIGHT

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,27 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+import pygame
+pygame.init()
+pygame.display.set_mode((1, 1))
+
+from asteroid import Asteroid
+from shot import Shot
+from constants import SCREEN_WIDTH, SCREEN_HEIGHT
+
+
+def test_asteroid_wraps():
+    a = Asteroid(SCREEN_WIDTH + 5, SCREEN_HEIGHT + 5, 20)
+    a.velocity = pygame.Vector2(0, 0)
+    a.update(0)
+    assert a.position.x == 0
+    assert a.position.y == 0
+
+
+def test_shot_wraps():
+    s = Shot(-5, -5)
+    s.velocity = pygame.Vector2(0, 0)
+    s.update(0)
+    assert s.position.x == SCREEN_WIDTH
+    assert s.position.y == SCREEN_HEIGHT


### PR DESCRIPTION
## Summary
- keep sprites on screen by wrapping Player, Asteroid and Shot positions
- cover wrapping behavior with basic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f20d4b17c832387f3733cf0a90dbe