### PR TITLE
Fix sprite inheritance

### DIFF
--- a/player.py
+++ b/player.py
@@ -12,12 +12,11 @@ from constants import (
 from shot import Shot
 
 
-class Player(pygame.sprite.Sprite, CircleShape):
-    containers = None # Will be set in main.py
+class Player(CircleShape):
+    containers = None  # Will be set in main.py
 
     def __init__(self, x, y):
-        pygame.sprite.Sprite.__init__(self)
-        CircleShape.__init__(self, x, y, PLAYER_RADIUS)
+        super().__init__(x, y, PLAYER_RADIUS)
         
         self.image = pygame.Surface([self.radius*2, self.radius*2], pygame.SRCALPHA)
         # The actual drawing of the triangle for display will be handled by the draw() method

--- a/powerup.py
+++ b/powerup.py
@@ -2,12 +2,11 @@ import pygame
 from circleshape import CircleShape # Assuming this is the correct path
 # from player import Player # Avoiding direct import for now to prevent circular dependency
 
-class PowerUp(pygame.sprite.Sprite, CircleShape):
-    containers = None # Will be set in main.py
+class PowerUp(CircleShape):
+    containers = None  # Will be set in main.py
 
     def __init__(self, x, y, radius, color, powerup_type, duration):
-        pygame.sprite.Sprite.__init__(self) # Initialize Sprite part
-        CircleShape.__init__(self, x, y, radius) # Initialize CircleShape part
+        super().__init__(x, y, radius)
         
         self.image = pygame.Surface([radius*2, radius*2], pygame.SRCALPHA)
         pygame.draw.circle(self.image, color, (radius, radius), radius)


### PR DESCRIPTION
## Summary
- simplify Player and PowerUp inheritance to avoid MRO errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f243984a48323a28b2f0b17160f77